### PR TITLE
Fiat currency config option

### DIFF
--- a/config.yml.sample
+++ b/config.yml.sample
@@ -4,6 +4,7 @@ passphrase: mypassphrase
 live: no
 frontend: curses
 logging: no
+fiat: USD
 periods:
   - name: BTC
     product: BTC-USD

--- a/curses_interface.py
+++ b/curses_interface.py
@@ -24,9 +24,9 @@ class cursesDisplay:
         self.pad.addstr(1, 0, "Waiting for a trade...")
 
     def update_balances(self, trade_engine):
-        self.pad.addstr(0, 0, "USD: %.2f BTC: %.8f ETH: %.8f LTC: %.8f USD_EQUIV: %.2f" %
-                        (trade_engine.usd, trade_engine.btc,
-                         trade_engine.eth, trade_engine.ltc, trade_engine.usd_equivalent))
+        self.pad.addstr(0, 0, "%s: %.2f BTC: %.8f ETH: %.8f LTC: %.8f %s_EQUIV: %.2f" %
+                        (trade_engine.fiat_currency, trade_engine.fiat, trade_engine.btc,
+                         trade_engine.eth, trade_engine.ltc, trade_engine.fiat_currency, trade_engine.fiat_equivalent))
 
     def update_candlesticks(self, period_list):
         starty = self.starty

--- a/engine.py
+++ b/engine.py
@@ -51,11 +51,12 @@ class Product(object):
 
 
 class TradeEngine():
-    def __init__(self, auth_client, product_list=['BTC-USD', 'ETH-USD', 'LTC-USD'], is_live=False):
+    def __init__(self, auth_client, product_list=['BTC-USD', 'ETH-USD', 'LTC-USD'], fiat='USD', is_live=False):
         self.logger = logging.getLogger('trader-logger')
         self.error_logger = logging.getLogger('error-logger')
         self.auth_client = auth_client
         self.product_list = product_list
+        self.fiat_currency = fiat
         self.is_live = is_live
         self.products = []
         self.stop_update_order_thread = True
@@ -65,7 +66,7 @@ class TradeEngine():
             self.products.append(Product(auth_client, product_id=product))
         self.last_balance_update = 0
         self.update_amounts()
-        self.usd_equivalent = 0
+        self.fiat_equivalent = 0
         self.last_balance_update = time.time()
         self.order_thread = threading.Thread()
 
@@ -106,7 +107,7 @@ class TradeEngine():
                     self.error_logger.exception(datetime.datetime.now())
             time.sleep(1)
 
-    def round_usd(self, money):
+    def round_fiat(self, money):
         return Decimal(money).quantize(Decimal('.01'), rounding=ROUND_DOWN)
 
     def round_coin(self, money):
@@ -114,7 +115,7 @@ class TradeEngine():
 
     def update_amounts(self):
         if time.time() - self.last_balance_update > 2.0:
-            self.usd_equivalent = Decimal('0.0')
+            self.fiat_equivalent = Decimal('0.0')
             try:
                 self.last_balance_update = time.time()
                 for account in self.auth_client.get_accounts():
@@ -124,23 +125,23 @@ class TradeEngine():
                         self.eth = self.round_coin(account.get('available'))
                     elif account.get('currency') == 'LTC':
                         self.ltc = self.round_coin(account.get('available'))
-                    elif account.get('currency') == 'USD':
-                        self.usd = self.round_usd(account.get('available'))
+                    elif account.get('currency') == self.fiat_currency:
+                        self.fiat = self.round_fiat(account.get('available'))
             except Exception:
                 self.error_logger.exception(datetime.datetime.now())
                 self.btc = Decimal('0.0')
                 self.eth = Decimal('0.0')
                 self.ltc = Decimal('0.0')
-                self.usd = Decimal('0.0')
+                self.fiat = Decimal('0.0')
                 return
 
             for product in self.products:
                 if product.order_book.get_current_ticker() and product.order_book.get_current_ticker().get('price'):
-                    self.usd_equivalent += self.get_base_currency_from_product_id(product.product_id) * Decimal(product.order_book.get_current_ticker().get('price'))
-            self.usd_equivalent += self.usd
+                    self.fiat_equivalent += self.get_base_currency_from_product_id(product.product_id) * Decimal(product.order_book.get_current_ticker().get('price'))
+            self.fiat_equivalent += self.fiat
 
     def print_amounts(self):
-        self.logger.debug("[BALANCES] USD: %.2f BTC: %.8f" % (self.usd, self.btc))
+        self.logger.debug("[BALANCES] %s: %.2f BTC: %.8f" % (self.fiat_currency, self.fiat, self.btc))
 
     def place_buy(self, product=None, partial='1.0'):
         amount = self.get_quoted_currency_from_product_id(product.product_id) * Decimal(partial)
@@ -254,9 +255,15 @@ class TradeEngine():
         self.update_amounts()
         if product_id == 'BTC-USD':
             return self.btc
+        elif product_id == 'BTC-EUR':
+            return self.btc
         elif product_id == 'ETH-USD':
             return self.eth
+        elif product_id == 'ETH-EUR':
+            return self.eth
         elif product_id == 'LTC-USD':
+            return self.ltc
+        elif product_id == 'LTC-EUR':
             return self.ltc
         elif product_id == 'ETH-BTC':
             return self.eth
@@ -266,11 +273,17 @@ class TradeEngine():
     def get_quoted_currency_from_product_id(self, product_id):
         self.update_amounts()
         if product_id == 'BTC-USD':
-            return self.usd
+            return self.fiat
+        elif product_id == 'BTC-EUR':
+            return self.fiat
         elif product_id == 'ETH-USD':
-            return self.usd
+            return self.fiat
+        elif product_id == 'ETH-EUR':
+            return self.fiat
         elif product_id == 'LTC-USD':
-            return self.usd
+            return self.fiat
+        elif product_id == 'LTC-EUR':
+            return self.fiat
         elif product_id == 'ETH-BTC':
             return self.btc
         elif product_id == 'LTC-BTC':
@@ -290,7 +303,7 @@ class TradeEngine():
                     new_buy_flag = new_buy_flag and Decimal(indicators[cur_period.name]['macd_hist']) > Decimal('0.0')
                     new_sell_flag = new_sell_flag or Decimal(indicators[cur_period.name]['macd_hist']) < Decimal('0.0')
                 else:
-                    if Decimal(indicators[cur_period.name[:-2] + '60']['adx']) > Decimal(25.0):
+                    if Decimal(indicators[cur_period.name]['adx']) > Decimal(25.0):
                         # Trending strategy
                         new_buy_flag = new_buy_flag and Decimal(indicators[cur_period.name]['obv']) > Decimal(indicators[cur_period.name]['obv_ema'])
                         new_sell_flag = new_sell_flag or Decimal(indicators[cur_period.name]['obv']) < Decimal(indicators[cur_period.name]['obv_ema'])
@@ -301,10 +314,10 @@ class TradeEngine():
                         new_sell_flag = new_sell_flag or Decimal(indicators[cur_period.name]['stoch_slowk']) < Decimal(indicators[cur_period.name]['stoch_slowd'])
 
             if product_id == 'LTC-BTC' or product_id == 'ETH-BTC':
-                ltc_or_eth_usd_product = self.get_product_by_product_id(product_id[:3] + '-USD')
-                btc_usd_product = self.get_product_by_product_id('BTC-USD')
-                new_buy_flag = new_buy_flag and ltc_or_eth_usd_product.buy_flag
-                new_sell_flag = new_sell_flag and btc_usd_product.buy_flag
+                ltc_or_eth_fiat_product = self.get_product_by_product_id(product_id[:3] + '-' + self.fiat_currency)
+                btc_fiat_product = self.get_product_by_product_id('BTC-' + self.fiat_currency)
+                new_buy_flag = new_buy_flag and ltc_or_eth_fiat_product.buy_flag
+                new_sell_flag = new_sell_flag and btc_fiat_product.buy_flag
 
             if new_buy_flag:
                 if product.sell_flag:

--- a/gdax-trader.py
+++ b/gdax-trader.py
@@ -18,13 +18,14 @@ from websocket import WebSocketConnectionClosedException
 
 
 class TradeAndHeartbeatWebsocket(gdax.WebsocketClient):
-    def __init__(self):
+    def __init__(self, fiat='USD'):
         self.logger = logging.getLogger('trader-logger')
         self.error_logger = logging.getLogger('error-logger')
+        self.fiat_currency = fiat
         super(TradeAndHeartbeatWebsocket, self).__init__()
 
     def on_open(self):
-        self.products = ["BTC-USD", 'ETH-USD', 'LTC-USD', 'ETH-BTC', 'LTC-BTC']
+        self.products = ["BTC-" + self.fiat_currency, 'ETH-' + self.fiat_currency, 'LTC-' + self.fiat_currency, 'ETH-BTC', 'LTC-BTC']
         self.type = "heartbeat"
         self.websocket_queue = queue.Queue()
         self.stop = False
@@ -82,9 +83,10 @@ for cur_period in config['periods']:
             trade_period_list[cur_period['product']] = []
         trade_period_list[cur_period['product']].append(new_period)
 
+fiat_currency = config['fiat']
 auth_client = gdax.AuthenticatedClient(config['key'], config['secret'], config['passphrase'])
-trade_engine = engine.TradeEngine(auth_client, product_list=product_list, is_live=config['live'])
-gdax_websocket = TradeAndHeartbeatWebsocket()
+trade_engine = engine.TradeEngine(auth_client, product_list=product_list, fiat=fiat_currency, is_live=config['live'])
+gdax_websocket = TradeAndHeartbeatWebsocket(fiat=fiat_currency)
 gdax_websocket.start()
 indicator_period_list[0].verbose_heartbeat = True
 indicator_subsys = indicators.IndicatorSubsystem(indicator_period_list)


### PR DESCRIPTION
Added a configuration option for fiat currency so USD is not hardcoded anymore. I am based in Europe and can only trade EUR pairs and original code was not working since my GDAX account only has EUR account.